### PR TITLE
Update Main.java

### DIFF
--- a/src/main/java/com/cognifide/securecq/cli/Main.java
+++ b/src/main/java/com/cognifide/securecq/cli/Main.java
@@ -45,7 +45,7 @@ public class Main {
 		}
 		boolean result = true;
 		for (TestLoader testLoader : TESTS) {
-			result = result && doTest(testLoader, cmdLine);
+			result = doTest(testLoader, cmdLine) && result;
 		}
 		System.exit(result ? 0 : -1);
 	}


### PR DESCRIPTION
as soon as `result` assumes the `false` value, `doTest()` won't be performed anymore (it's a JVM optimisation).

inverting the order, makes sure that ALL the tests will be performed and the report will be complete
